### PR TITLE
Update "Internal State and Actions" page to reflect easy-peasy removal

### DIFF
--- a/src/markdown/docs/api/internal-state-actions.md
+++ b/src/markdown/docs/api/internal-state-actions.md
@@ -2,7 +2,7 @@
 title: Internal State and Actions
 ---
 
-Under the hood React Flow uses [Easy Peasy](https://easy-peasy.now.sh/) for state handling.
+Under the hood React Flow uses [Redux](https://redux.js.org/) for state handling.
 If you need to access the internal state you can use the `useStoreState` hook inside a child component of the `ReactFlow` component:
 
 ### Internal state


### PR DESCRIPTION
Hi there, was just taking a look at the code and reviewing the docs in preparation for trying out react-flow. It looks like `easy-peasy` is no longer used and it's just plain Redux now, right? This PR fixes the old reference to `easy-peasy`.