### PR TITLE
Update custom node example

### DIFF
--- a/src/markdown/docs/api/node-types/index.md
+++ b/src/markdown/docs/api/node-types/index.md
@@ -58,7 +58,7 @@ A basic implementation of a custom node could look like this:
 
 ```jsx
 import React from 'react';
-import ReactFlow, { Handle } from 'react-flow-renderer';
+import ReactFlow, { Handle, Position } from 'react-flow-renderer';
 
 const elements = [
   {
@@ -78,17 +78,17 @@ const customNodeStyles = {
 const CustomNodeComponent = ({ data }) => {
   return (
     <div style={customNodeStyles}>
-      <Handle type="target" position="left" style={{ borderRadius: 0 }} />
+      <Handle type="target" position={Position.Left} style={{ borderRadius: 0 }} />
       <div>{data.text}</div>
       <Handle
         type="source"
-        position="right"
+        position={Position.Right}
         id="a"
         style={{ top: '30%', borderRadius: 0 }}
       />
       <Handle
         type="source"
-        position="right"
+        position={Position.Right}
         id="b"
         style={{ top: '70%', borderRadius: 0 }}
       />


### PR DESCRIPTION
Passing a string as position causes a Typescript error:
```
Type '"left"' is not assignable to type 'Position'.ts(2322)
index.d.ts(305, 5): The expected type comes from property 'position' which is declared here on type 'IntrinsicAttributes & HandleProps & Omit<HTMLAttributes<HTMLDivElement>, "id"> & RefAttributes<HTMLDivElement>'
```

Updating the example to use the Position enum instead.